### PR TITLE
chore: update Sentry configuration and routes type reference

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,6 +24,16 @@ export default withSentryConfig(nextConfig, {
 
   project: "beuty-salon-demo",
 
+  // Turbopack runs release creation + source map upload in `runAfterProductionCompile`. Without a
+  // valid SENTRY_AUTH_TOKEN, sentry-cli fails (401) and Vercel fails the build. Skip that hook
+  // until the token is set under Vercel → Project → Environment Variables.
+  ...(process.env.SENTRY_AUTH_TOKEN
+    ? {}
+    : {
+        sourcemaps: { disable: true },
+        useRunAfterProductionCompileHook: false,
+      }),
+
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
 


### PR DESCRIPTION
- Modify next-env.d.ts to reference the updated routes type definition.
- Update next.config.mjs to conditionally disable sourcemaps and the runAfterProductionCompile hook if SENTRY_AUTH_TOKEN is not set, preventing build failures on Vercel.